### PR TITLE
Add install targets

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,0 @@
-[submodule "third-party/stringpool"]
-	path = third-party/stringpool
-	url = https://github.com/m-ou-se/string-pool

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -11,7 +11,7 @@ endif()
 find_package(mstd)
 find_package(stringpool)
 
-add_library(conftaal-parser STATIC
+add_library(conftaal-parser
 	src/operator.cpp
 	src/parse.cpp
 	src/print_error.cpp

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -8,8 +8,12 @@ if (CMAKE_COMPILER_IS_GNUCXX)
 	set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wall -Wextra -pedantic -Wno-sign-compare")
 endif()
 
-find_package(mstd)
-find_package(stringpool)
+if (NOT TARGET mstd)
+	find_package(mstd)
+endif()
+if (NOT TARGET stringpool::string_pool)
+	find_package(stringpool)
+endif()
 
 add_library(conftaal-parser
 	src/operator.cpp
@@ -24,13 +28,13 @@ add_executable(conftaal-test
 target_link_libraries(conftaal-test conftaal-parser)
 
 add_custom_target(check
-	COMMAND "${CMAKE_SOURCE_DIR}/test/test" "$<TARGET_FILE:conftaal-test>"
+	COMMAND "${CMAKE_CURRENT_SOURCE_DIR}/test/test" "$<TARGET_FILE:conftaal-test>"
 	DEPENDS conftaal-test
 	USES_TERMINAL
 )
 
 add_custom_target(update-tests
-	COMMAND "${CMAKE_SOURCE_DIR}/test/test" "--update-expected" "$<TARGET_FILE:conftaal-test>"
+	COMMAND "${CMAKE_CURRENT_SOURCE_DIR}/test/test" "--update-expected" "$<TARGET_FILE:conftaal-test>"
 	DEPENDS conftaal-test
 	USES_TERMINAL
 )

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -34,3 +34,16 @@ add_custom_target(update-tests
 	DEPENDS conftaal-test
 	USES_TERMINAL
 )
+
+# Install libraries.
+include(GNUInstallDirs)
+install(TARGETS conftaal-parser EXPORT ${PROJECT_NAME}
+	ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR}
+	LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
+)
+
+# Install CMake configuration files.
+configure_file(config.cmake.in ${PROJECT_NAME}-config.cmake @ONLY)
+set(CMAKE_INSTALL_CMAKEDIR "lib/cmake/${PROJECT_NAME}" CACHE PATH "CMake project files")
+install(EXPORT ${PROJECT_NAME} DESTINATION ${CMAKE_INSTALL_CMAKEDIR} NAMESPACE ${PROJECT_NAME}::)
+install(FILES "${CMAKE_CURRENT_BINARY_DIR}/${PROJECT_NAME}-config.cmake" DESTINATION "${CMAKE_INSTALL_CMAKEDIR}")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -16,7 +16,7 @@ add_library(conftaal-parser
 	src/parse.cpp
 	src/print_error.cpp
 )
-target_link_libraries(conftaal-parser mstd string_tracker)
+target_link_libraries(conftaal-parser mstd stringpool::string_tracker)
 
 add_executable(conftaal-test
 	src/test.cpp

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -8,11 +8,8 @@ if (CMAKE_COMPILER_IS_GNUCXX)
 	set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wall -Wextra -pedantic -Wno-sign-compare")
 endif()
 
-if(EXISTS ${CMAKE_CURRENT_SOURCE_DIR}/third-party/mstd/CMakeLists.txt)
-	add_subdirectory(third-party/mstd)
-endif()
-
-add_subdirectory(third-party/stringpool)
+find_package(mstd)
+find_package(stringpool)
 
 add_library(conftaal-parser STATIC
 	src/operator.cpp

--- a/config.cmake.in
+++ b/config.cmake.in
@@ -1,0 +1,5 @@
+include(CMakeFindDependencyMacro)
+find_dependency(mstd)
+find_dependency(stringpool)
+
+include(${CMAKE_CURRENT_LIST_DIR}/@PROJECT_NAME@.cmake)


### PR DESCRIPTION
Should be suitable for both use as in-tree module and system wide dependency.

Also removes the `stringpool` submodule. It should either be provided by a top-level `CMakeLists.txt` (with `add_subdirectory`) or as CMake package (for use with `find_package`).